### PR TITLE
add answered question button in interface

### DIFF
--- a/plugins/nodebb-plugin-digitalpioneers/templates/partials/topics_list.tpl
+++ b/plugins/nodebb-plugin-digitalpioneers/templates/partials/topics_list.tpl
@@ -8,7 +8,7 @@
 		<meta itemprop="position" content="{increment(./index, "1")}" />
 		<a id="{./index}" data-index="{./index}" component="topic/anchor"></a>
 
-		<div class="d-flex p-0 col-12 col-lg-7 gap-2 gap-lg-3 pe-1 align-items-start {{{ if config.theme.mobileTopicTeasers }}}mb-2 mb-lg-0{{{ end }}}">
+		<div class="d-flex p-0 col-12 col-lg-4 gap-2 gap-lg-3 pe-1 align-items-start {{{ if config.theme.mobileTopicTeasers }}}mb-2 mb-lg-0{{{ end }}}">
 			<div class="flex-shrink-0 position-relative">
 				<a class="text-decoration-none" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}">
 					{buildAvatar(./user, "40px", true, "avatar avatar-tooltip")}
@@ -86,8 +86,15 @@
 			{{{ end }}}
 		</div>
 
-		<div class="d-flex p-0 col-lg-5 col-12 align-content-stretch">
-			<div class="meta stats d-none d-lg-grid col-6 gap-1 pe-2 text-muted" style="grid-template-columns: 1fr 1fr 1fr;">
+		<div class="d-flex p-0 col-lg-8 col-12 align-content-stretch">
+			<div class="meta stats d-none d-lg-grid col-lg-8 col-12 gap-1 pe-2 text-muted" style="grid-template-columns: 1fr 1fr 1fr;">
+				{{{ if !./unreplied }}}
+				<div class="border-0 p-2 overflow-hidden rounded-1 d-flex flex-column align-items-center">
+                    <button style="border: none;" onclick="toggleReplyStatus({./index})">
+                        <i component="topic/replies" class="fa fa-fw text-primary fa-sharp fa-solid fa-square-check" title="Mark as replied"></i>
+                    </button>
+        		</div>
+				{{{ end }}}
 				{{{ if !reputation:disabled }}}
 				<div class="stats-votes card card-header border-0 p-2 overflow-hidden rounded-1 d-flex flex-column align-items-center">
 					<span class="fs-5 ff-secondary lh-1" title="{./votes}">{humanReadableNumber(./votes, 0)}</span>
@@ -106,7 +113,7 @@
 					<i class="d-xl-none fa fa-fw text-xs text-muted opacity-75 fa-eye"></i>
 				</div>
 			</div>
-			<div component="topic/teaser" class="meta teaser col-lg-6 col-12 {{{ if !config.theme.mobileTopicTeasers }}}d-none d-lg-block{{{ end }}}">
+			<div component="topic/teaser" class="meta teaser col-lg-4 col-12 {{{ if !config.theme.mobileTopicTeasers }}}d-none d-lg-block{{{ end }}}">
 				<div class="lastpost border-start border-2 lh-sm h-100 d-flex flex-column gap-1" style="border-color: {./category.bgColor}!important;">
 					{{{ if ./unreplied }}}
 					<div class="ps-2 text-xs">


### PR DESCRIPTION
Se crea un botón de tipo check en el tema creado dentro de los tópicos para resolver el issue https://github.com/USB-CI3715/nodebb-usb-24-digitalpioneers/issues/32.
Cambios incluidos:

Se agrega un botón de tipo check directamente al lado de las estadísticas de los temas, específicamente al lado del número global de votos.
Archivos Modificados:

Dentro de la carpeta plugins\nodebb-plugin-digitalpioneers\templates\partials se encuentra el archivo topics_list.tpl que fue el archivo modificado, donde se localizaron las estadísticas de los temas y se modifico el espacio a tomar en cuenta para poder mostrar el botón a agregar.

Foto del después:
![image](https://github.com/user-attachments/assets/f8b84647-0b15-4a4f-bb41-a326fdcf6569)

Resolves https://github.com/USB-CI3715/nodebb-usb-24-digitalpioneers/issues/32