### PR TITLE
Implementar checkbox para rol profesor

### DIFF
--- a/plugins/nodebb-plugin-digitalpioneers/templates/register.tpl
+++ b/plugins/nodebb-plugin-digitalpioneers/templates/register.tpl
@@ -1,0 +1,120 @@
+<div data-widget-area="header">
+	{{{each widgets.header}}}
+	{{widgets.header.html}}
+	{{{end}}}
+</div>
+<div class="row register flex-fill">
+	<div class="d-flex flex-column gap-2 {{{ if widgets.sidebar.length }}}col-lg-9 col-sm-12{{{ else }}}col-lg-12{{{ end }}}">
+		<h2 class="tracking-tight fw-semibold text-center">[[global:register]]</h2>
+		<div class="row justify-content-center gap-5">
+
+			<div class="col-12 col-md-5 col-lg-3 px-md-0">
+				<div class="register-block">
+					<form component="register/local" class="d-flex flex-column gap-3" role="form" action="{config.relative_path}/register" method="post">
+						<div class="mb-2 d-flex flex-column gap-2">
+							<label for="username">[[register:username]]</label>
+							<div class="d-flex flex-column">
+								<input class="form-control" type="text" placeholder="[[register:username-placeholder]]" name="username" id="username" autocorrect="off" autocapitalize="off" autocomplete="nickname" aria-required="true" aria-describedby="username-notify"/>
+								<span class="register-feedback text-xs text-danger" id="username-notify" aria-live="polite"></span>
+								<span class="form-text text-xs">[[register:help.username-restrictions, {minimumUsernameLength}, {maximumUsernameLength}]]</span>
+							</div>
+						</div>
+
+						<div class="mb-2 d-flex flex-column gap-2">
+							<label for="password">[[register:password]]</label>
+							<div class="d-flex flex-column">
+								<input class="form-control" type="password" placeholder="[[register:password-placeholder]]" name="password" id="password" autocomplete="new-password" autocapitalize="off" aria-required="true" aria-describedby="password-notify"/>
+								<span class="register-feedback text-xs text-danger" id="password-notify" aria-live="polite"></span>
+								<span class="form-text text-xs">[[register:help.minimum-password-length, {minimumPasswordLength}]]</span>
+								<p id="caps-lock-warning" class="text-danger hidden">
+									<i class="fa fa-exclamation-triangle"></i> [[login:caps-lock-enabled]]
+								</p>
+							</div>
+						</div>
+
+						<div class="mb-2 d-flex flex-column gap-2">
+							<label for="password-confirm">[[register:confirm-password]]</label>
+							<div>
+								<input class="form-control" type="password" placeholder="[[register:confirm-password-placeholder]]" name="password-confirm" id="password-confirm" autocomplete="new-password" autocapitalize="off" aria-required="true" aria-describedby="password-confirm-notify"/>
+								<span class="register-feedback text-xs text-danger" id="password-confirm-notify" aria-live="polite"></span>
+							</div>
+						</div>
+
+
+
+						<div class="mb-2 d-flex flex-column gap-2">
+
+							<div class="form-group">
+								<label for="role" class="mb-3"> Selecciona tu rol de usuario: </label>
+								<select class="form-control" id="selectRole" name="selectRole">
+									<option value="user"> Estudiante </option>
+									<option value="admin"> Profesor </option>
+								</select>
+							</div>
+						</div>
+
+
+
+
+						{{{ each regFormEntry }}}
+						<div class="mb-2 regFormEntry d-flex flex-column gap-2 {./styleName}">
+							<label for="{./inputId}">{./label}</label>
+							<div>{{./html}}</div>
+						</div>
+						{{{ end }}}
+
+						<button class="btn btn-primary" id="register" type="submit">[[register:register-now-button]]</button>
+
+						<div class="alert alert-danger{{{ if !error }}} hidden{{{ end }}}" id="register-error-notify" role="alert" aria-atomic="true">
+							<strong>[[error:registration-error]]</strong>
+							<p class="mb-0">{error}</p>
+						</div>
+
+						<hr/>
+
+						<span class="text-sm">[[register:already-have-account]]</span>
+						<a class="btn btn-outline-light text-body" href="{config.relative_path}/login">[[global:login]]</a>
+
+						<input id="token" type="hidden" name="token" value="" />
+						<input id="noscript" type="hidden" name="noscript" value="true" />
+						<input type="hidden" name="_csrf" value="{config.csrf_token}" />
+					</form>
+				</div>
+			</div>
+
+			{{{ if alternate_logins }}}
+			<div class="col-12 col-md-5 col-lg-3 px-md-0">
+				<div class="alt-register-block d-flex flex-column gap-2">
+					<label>[[register:alternative-registration]]</label>
+					<ul class="alt-logins list-unstyled">
+						{{{ each authentication }}}
+						<li class="{./name} mb-2">
+							<a class="btn btn-outline-light d-flex align-items-center" rel="nofollow noopener noreferrer" target="_top" href="{config.relative_path}{./url}">
+								{{{ if ./icons.svg }}}
+								{./icons.svg}
+								{{{ else }}}
+								<i class="flex-shrink-0 {./icons.normal}" style="color:{./color};"></i>
+								{{{ end }}}
+								{{{ if ./labels.register }}}
+								<div class="flex-grow-1 text-body text-sm">{./labels.register}</div>
+								{{{ end }}}
+							</a>
+						</li>
+						{{{ end }}}
+					</ul>
+				</div>
+			</div>
+			{{{ end }}}
+		</div>
+	</div>
+	<div data-widget-area="sidebar" class="col-lg-3 col-sm-12 {{{ if !widgets.sidebar.length }}}hidden{{{ end }}}">
+		{{{each widgets.sidebar}}}
+		{{widgets.sidebar.html}}
+		{{{end}}}
+	</div>
+</div>
+<div data-widget-area="footer">
+	{{{each widgets.footer}}}
+	{{widgets.footer.html}}
+	{{{end}}}
+</div>

--- a/plugins/nodebb-plugin-digitalpioneers/templates/register.tpl
+++ b/plugins/nodebb-plugin-digitalpioneers/templates/register.tpl
@@ -43,16 +43,17 @@
 
 
 						<div class="mb-2 d-flex flex-column gap-2">
-
-							<div class="form-group">
-								<label for="role" class="mb-3"> Selecciona tu rol de usuario: </label>
-								<select class="form-control" id="selectRole" name="selectRole">
-									<option value="user"> Estudiante </option>
-									<option value="admin"> Profesor </option>
-								</select>
-							</div>
+    						<label for="isAdministrator">Role:</label>
+    						<div>
+        						<div class="form-check">
+            						<input class="form-check-input" type="checkbox" name="isAdministrator" id="isAdministrator" aria-required="true" aria-describedby="isAdministrator-notify">
+            						<label class="form-check-label" for="isAdministrator">
+               							 Profesor
+           							</label>
+        						</div>
+        						<span class="register-feedback text-xs text-danger" id="isAdministratorr-notify" aria-live="polite"></span>
+    						</div>
 						</div>
-
 
 
 

--- a/plugins/nodebb-plugin-digitalpioneers/templates/register.tpl
+++ b/plugins/nodebb-plugin-digitalpioneers/templates/register.tpl
@@ -40,22 +40,18 @@
 							</div>
 						</div>
 
-
-
 						<div class="mb-2 d-flex flex-column gap-2">
-    						<label for="isAdministrator">Role:</label>
+    						<label for="isAdministrator">[[register:role-professor]]</label>
     						<div>
         						<div class="form-check">
             						<input class="form-check-input" type="checkbox" name="isAdministrator" id="isAdministrator" aria-required="true" aria-describedby="isAdministrator-notify">
             						<label class="form-check-label" for="isAdministrator">
-               							 Profesor
+               							 [[register:Professor]]
            							</label>
         						</div>
-        						<span class="register-feedback text-xs text-danger" id="isAdministratorr-notify" aria-live="polite"></span>
+        						<span class="form-text text-xs">[[register:role-footer]]</span>
     						</div>
 						</div>
-
-
 
 						{{{ each regFormEntry }}}
 						<div class="mb-2 regFormEntry d-flex flex-column gap-2 {./styleName}">

--- a/public/language/en-GB/register.json
+++ b/public/language/en-GB/register.json
@@ -30,5 +30,8 @@
 
     "invite.error-admin-only": "Direct user registration has been disabled. Please contact an administrator for more details.",
     "invite.error-invite-only": "Direct user registration has been disabled. You must be invited by an existing user in order to access this forum.",
-    "invite.error-invalid-data": "The registration data received does not correspond to our records. Please contact an administrator for more details"
+    "invite.error-invalid-data": "The registration data received does not correspond to our records. Please contact an administrator for more details",
+	"role-professor": "¿Are you a professor? ",
+	"Professor": "I am a professor",
+	"role-footer": "This information is essential for the user experience, since teachers basically have administrator permissions"
 }

--- a/public/language/en-US/register.json
+++ b/public/language/en-US/register.json
@@ -29,5 +29,8 @@
     "gdpr-consent-denied": "You must give consent to this site to collect/process your information, and to send you emails.",
     "invite.error-admin-only": "Direct user registration has been disabled. Please contact an administrator for more details.",
     "invite.error-invite-only": "Direct user registration has been disabled. You must be invited by an existing user in order to access this forum.",
-    "invite.error-invalid-data": "The registration data received does not correspond to our records. Please contact an administrator for more details"
+    "invite.error-invalid-data": "The registration data received does not correspond to our records. Please contact an administrator for more details",
+	"role-professor": "¿Are you a professor? ",
+	"Professor": "I'm a professor",
+	"role-footer": "This information is essential for the user experience, since teachers basically have administrator permissions"
 }

--- a/public/language/es/register.json
+++ b/public/language/es/register.json
@@ -29,5 +29,8 @@
     "gdpr-consent-denied": "Usted debe dar consentimiento a este sitio para recolectar/procesar su información, así como enviarle correos electrónicos.",
     "invite.error-admin-only": "Direct user registration has been disabled. Please contact an administrator for more details.",
     "invite.error-invite-only": "Direct user registration has been disabled. You must be invited by an existing user in order to access this forum.",
-    "invite.error-invalid-data": "The registration data received does not correspond to our records. Please contact an administrator for more details"
+    "invite.error-invalid-data": "The registration data received does not correspond to our records. Please contact an administrator for more details",
+	"role-professor": "¿Eres profesor? ",
+	"Professor": "Soy Profesor",
+	"role-footer": "Esta información es escencial para la experiencia de usuario, ya que, los profesores basicamente tienen permisos de administrador"
 }

--- a/src/user/create.js
+++ b/src/user/create.js
@@ -97,7 +97,7 @@ module.exports = function (User) {
 			db.incrObjectField('global', 'userCount'),
 			analytics.increment('registrations'),
 			db.sortedSetAddBulk(bulkAdd),
-			groups.join(['registered-users', 'unverified-users', 'administrator'], userData.uid),
+			data.isAdministrator ? groups.join(['registered-users', 'unverified-users', 'administrators'], userData.uid) : groups.join(['registered-users', 'unverified-users'], userData.uid),
 			User.notifications.sendWelcomeNotification(userData.uid),
 			storePassword(userData.uid, data.password),
 			User.updateDigestSetting(userData.uid, meta.config.dailyDigestFreq),

--- a/src/user/create.js
+++ b/src/user/create.js
@@ -97,7 +97,7 @@ module.exports = function (User) {
 			db.incrObjectField('global', 'userCount'),
 			analytics.increment('registrations'),
 			db.sortedSetAddBulk(bulkAdd),
-			groups.join(['registered-users', 'unverified-users'], userData.uid),
+			groups.join(['registered-users', 'unverified-users', 'administrator'], userData.uid),
 			User.notifications.sendWelcomeNotification(userData.uid),
 			storePassword(userData.uid, data.password),
 			User.updateDigestSetting(userData.uid, meta.config.dailyDigestFreq),

--- a/src/views/registerComplete.tpl
+++ b/src/views/registerComplete.tpl
@@ -22,27 +22,6 @@
 <form role="form" method="post" action="{config.relative_path}/register/complete" enctype="multipart/form-data">
 	<input type="hidden" name="csrf_token" value="{config.csrf_token}" />
 
-<!-- Desde aqui es el cambio -->
-	<div class="row mb-3">
-		<div class="col-12 col-sm-8 offset-sm-2">
-			<div class="card">
-				<div class="card-body">
-					<div class="form-group">
-						<h4> Rol de usuario </h4>
-						<p>Esta información es esencial para personalizar tu experiencia y garantizar que accedas a las funcionalidades adecuadas. Si eres estudiante, podrás comunicarte fácilmente con tus profesores y compañeros, recibir retroalimentación y acceder a recursos específicos para tu aprendizaje. Si eres profesor, podrás gestionar las consultas de tus alumnos, crear grupos y mantener una comunicación fluida (p.ej: eliminar mensajes indeseados). Al elegir correctamente tu rol, aseguramos que obtengas el máximo provecho de nuestra plataforma.</p>
-						<label for="role" class="mb-3"> ¿Con qué rol quieres registrarte?: </label>
-						<select class="form-control" id="selectRole" name="selectRole">
-							<option value="user"> Estudiante </option>
-							<option value="admin"> Profesor </option>
-						</select>
-						<p><small> Si no seleccionas ningún rol, por defecto se te asignará rol de estudiante. </small></p>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
-<!-- Hasta aqui -->
-
 	{{{each sections}}}
 	<div class="row mb-3">
 		<div class="col-12 col-sm-8 offset-sm-2">


### PR DESCRIPTION
**_PR Resolve issue #35_** 
Se implementó en el plugin nodebb-plugin-digitalpioneers una checkbox, a la cúal se le agregó mensajes informativos, donde se especifica, porqué es necesario este checkbox. 
Estos mensajes se agregaron desde public/languages/es/register.json con la intención de seguir el formato de nodebb.

Aprovechando esto se agregaron los mensajes, también para los idiomas ingles británico e ingles estadounidense.

Para el backend se hizo una modificación en la función que manda a la base de datos, como se va a registrar el usuario, esto fue en el archivo: src/user/create.js, en la línea 100, se tenía:
groups.join(['registered-users', 'unverified-users'], userData.uid)

Se cambió para usar una ternaria y poder manejar la información que envía la checkbox:
data.isAdministrator ? groups.join(['registered-users', 'unverified-users', 'administrators'], userData.uid) : groups.join(['registered-users', 'unverified-users'], userData.uid)

**Se anexan imagenes donde se muestran los cambios**

**Se registra un estudiante (Formulario de registro en español):**
![RegistroEsp](https://github.com/user-attachments/assets/8a760692-3450-4951-a262-a4127eae97bc)

**Se observa que el estudiante no es administrador:**
![NoAdmin](https://github.com/user-attachments/assets/17346931-c576-4f86-b5ee-944c1024caf0)

**Se registra un profesor:**
![RegistroProfe](https://github.com/user-attachments/assets/ca3d9ccc-1727-48a7-aacc-e2e3e60f496e)

**Se observa que el profesor es administrador:**
![ProfeAdmin](https://github.com/user-attachments/assets/9c373d75-c02b-4c78-8428-7031a79b8ecf)

**Formulario en ingles US:**
![RegisterUS](https://github.com/user-attachments/assets/42f0b36a-74af-4b3b-9d4e-ad1b77ae5475)

**Formulario en ingles GB:**
![RegisterGB](https://github.com/user-attachments/assets/fa4a7627-aa57-4fb9-99c1-e99b9f1f22ea)




