### PR TITLE
Muestra rol en perfil

### DIFF
--- a/plugins/nodebb-plugin-digitalpioneers/templates/account/profile.tpl
+++ b/plugins/nodebb-plugin-digitalpioneers/templates/account/profile.tpl
@@ -1,0 +1,95 @@
+<!-- IMPORT partials/account/header.tpl -->
+
+{{{ if widgets.profile-aboutme-before.length }}}
+<div data-widget-area="profile-aboutme-before">
+{{{each widgets.profile-aboutme-before}}}
+{./html}
+{{{end}}}
+</div>
+{{{ end }}}
+
+{{{ if aboutme }}}
+<div component="aboutme" class="text-sm text-break">
+{aboutmeParsed}
+</div>
+{{{ end }}}
+
+{{{ if widgets.profile-aboutme-after.length }}}
+<div data-widget-area="profile-aboutme-after">
+{{{each widgets.profile-aboutme-after}}}
+{./html}
+{{{end}}}
+</div>
+{{{ end }}}
+
+<div class="account-stats container">
+	<div class="row row-cols-2 row-cols-xl-3 row-cols-xxl-4 g-2">
+		{{{ if !reputation:disabled }}}
+		<div class="stat">
+			<div class="align-items-center justify-content-center card card-header px-0 py-3 border-0 rounded-1 h-100">
+				<span class="stat-label text-xs fw-semibold">[[global:reputation]]</span>
+				<span class="fs-2 ff-secondary" title="{reputation}">{humanReadableNumber(reputation)}</span>
+			</div>
+		</div>
+		{{{ end }}}
+		<div class="stat">
+			<div class="align-items-center justify-content-center card card-header px-0 py-3 border-0 rounded-1 h-100">
+				<span class="stat-label text-xs fw-semibold">[[user:profile-views]]</span>
+				<span class="fs-2 ff-secondary" title="
+				{profileviews}">{humanReadableNumber(profileviews)}</span>
+			</div>
+		</div>
+
+		<div class="stat">
+			<div class="align-items-center justify-content-center card card-header px-0 py-3 border-0 rounded-1 h-100 gap-2">
+				<span class="stat-label text-xs fw-semibold"><i class="text-muted fa-solid fa-user-plus"></i> <span>[[user:joined]]</span></span>
+				<span class="timeago fs-6 ff-secondary" title="{joindateISO}"></span>
+			</div>
+		</div>
+
+		<div class="stat">
+			<div class="align-items-center justify-content-center card card-header px-0 py-3 border-0 rounded-1 h-100 gap-2">
+				<span class="stat-label text-xs fw-semibold"><i class="text-muted fa-solid fa-clock"></i> <span>[[user:lastonline]]</span></span>
+				<span class="timeago text-center text-break w-100 px-2 fs-6 ff-secondary" title="{lastonlineISO}"></span>
+			</div>
+		</div>
+
+		{{{ if email }}}
+		<div class="stat">
+			<div class="align-items-center justify-content-center card card-header px-0 py-3 border-0 rounded-1 h-100 gap-2">
+				<span class="stat-label text-xs fw-semibold"><i class="text-muted fa-solid fa-envelope"></i> <span>[[user:email]]</span> {{{ if emailHidden}}}<span class="text-lowercase">([[global:hidden]])</span>{{{ end }}}</span>
+				<span class="text-sm text-center text-break w-100 px-2 ff-secondary">{email}</span>
+			</div>
+		</div>
+		{{{ end }}}
+
+		{{{ if websiteName }}}
+		<div class="stat">
+			<div class="align-items-center justify-content-center card card-header px-0 py-3 border-0 rounded-1 h-100 gap-2">
+				<span class="stat-label text-xs fw-semibold"><i class="text-muted fa-solid fa-globe"></i> <span>[[user:website]]</span></span>
+				<a class="text-sm text-center text-break w-100 px-2 ff-secondary text-underline text-reset" href="{websiteLink}" rel="nofollow noreferrer me">{websiteName}</a>
+			</div>
+		</div>
+		{{{ end }}}
+
+		{{{ if location }}}
+		<div class="stat">
+			<div class="align-items-center justify-content-center card card-header px-0 py-3 border-0 rounded-1 h-100 gap-2">
+				<span class="stat-label text-xs fw-semibold"><i class="text-muted fa-solid fa-map-pin"></i> <span>[[user:location]]</span></span>
+				<span class="text-center text-break w-100 px-2 fs-6 ff-secondary">{location}</span>
+			</div>
+		</div>
+		{{{ end }}}
+
+		{{{ if age }}}
+		<div class="stat">
+			<div class="align-items-center justify-content-center card card-header px-0 py-3 border-0 rounded-1 h-100 gap-2">
+				<span class="stat-label text-xs fw-semibold"><span><i class="text-muted fa-solid fa-cake-candles"></i> [[user:age]]</span></span>
+				<span class="fs-6 ff-secondary">{age}</span>
+			</div>
+		</div>
+		{{{ end }}}
+	</div>
+</div>
+
+<!-- IMPORT partials/account/footer.tpl -->

--- a/plugins/nodebb-plugin-digitalpioneers/templates/partials/account/header.tpl
+++ b/plugins/nodebb-plugin-digitalpioneers/templates/partials/account/header.tpl
@@ -1,0 +1,99 @@
+<div class="account w-100 mx-auto">
+	<div data-widget-area="header">
+		{{{each widgets.header}}}
+		{{widgets.header.html}}
+		{{{end}}}
+	</div>
+
+	<div class="cover position-absolute start-0 top-0 w-100" component="account/cover" style="background-image: url({cover:url}); background-position: {cover:position};">
+		<div class="container">
+			{{{ if allowCoverPicture }}}
+			{{{ if canEdit }}}
+			<div class="controls text-center">
+				<span class="upload p-2 m-2 rounded-1 text-bg-light opacity-75"><i class="fa fa-fw fa-upload"></i></span>
+				<span class="resize p-2 m-2 rounded-1 text-bg-light opacity-75"><i class="fa fa-fw fa-arrows"></i></span>
+				<span class="remove p-2 m-2 rounded-1 text-bg-light opacity-75"><i class="fa fa-fw fa-times"></i></span>
+			</div>
+			<div class="save text-bg-primary">[[groups:cover-save]] <i class="fa fa-fw fa-floppy-o"></i></div>
+			<div class="indicator text-bg-primary">[[groups:cover-saving]] <i class="fa fa-fw fa-refresh fa-spin"></i></div>
+			{{{ end }}}
+			{{{ end }}}
+		</div>
+	</div>
+
+	<div class="d-flex flex-column flex-md-row gap-2 w-100 pb-4 mb-4 mt-2 border-bottom">
+		<div {{{ if (allowProfilePicture && isSelfOrAdminOrGlobalModerator)}}}component="profile/change/picture"{{{ end }}} class="avatar-wrapper border border-white border-4 rounded-circle position-relative align-self-center align-self-md-start hover-parent" style="margin-top: -75px;">
+			{buildAvatar(@value, "142px", true)}
+			{{{ if (allowProfilePicture && isSelfOrAdminOrGlobalModerator)}}}
+			<div component="profile/change/picture" class="d-none d-md-block pointer p-2 rounded-1 opacity-75 text-bg-light position-absolute top-50 start-50 translate-middle hover-visible">
+				<span class="upload"><i class="fa fa-fw fa-upload"></i></span>
+			</div>
+			{{{ end }}}
+		</div>
+
+		<div class="d-flex flex-column flex-md-row mt-1 justify-content-between w-100 gap-2">
+			<div class="d-flex flex-grow-1 flex-row gap-2">
+				<div class="d-flex flex-column gap-1">
+					<h2 class="fullname fw-semibold fs-2 tracking-tight mb-0">{{{ if fullname }}}{fullname}{{{ else }}}{username}{{{ end }}}</h2>
+					<h2 class="fullname fw-semibold fs-2 tracking-tight mb-0">{{{ if isAdmin }}}[[user:professor-role]]{{{ else }}}[[user:student-role]]{{{ end }}}</h2>
+					<div class="d-flex flex-wrap gap-1 text-sm align-items-center">
+						<span class="username fw-bold">{{{ if !banned }}}@{username}{{{ else }}}[[user:banned]]{{{ end }}}</span>
+						<div class="d-flex align-items-center gap-1 p-1">
+							{{{ if selectedGroup.length }}}
+							{{{ each selectedGroup }}}
+							{{{ if ./slug }}}
+							<!-- IMPORT partials/groups/badge.tpl -->
+							{{{ end }}}
+							{{{ end }}}
+							{{{ end }}}
+						</div>
+					</div>
+					<div class="d-flex gap-2" component="user/badges"></div>
+					{{{ if isAdminOrGlobalModeratorOrModerator }}}
+					{{{ if banned }}}
+					<div class="text-xm text-muted">
+						{{{ if banned_until }}}
+						[[user:info.banned-until, {banned_until_readable}]]
+						{{{ else }}}
+						[[user:info.banned-permanently]]
+						{{{ end }}}
+					</div>
+					{{{ end }}}
+					{{{ end }}}
+				</div>
+			</div>
+
+			<div class="flex-shrink-0 d-flex gap-1 align-self-stretch align-self-md-start justify-content-end">
+				{{{ if loggedIn }}}
+				{{{ if !isSelf }}}
+				<a component="account/unfollow" href="#" class="btn btn-info flex-fill{{{ if !isFollowing }}} hide{{{ end }}}">[[user:unfollow]]</a>
+				<a component="account/follow" href="#" class="btn btn-primary flex-fill{{{ if isFollowing }}} hide{{{ end }}}">[[user:follow]]</a>
+				{{{ end }}}
+				{{{ end }}}
+
+				{{{ if (canChat && !banned) }}}
+				<div class="btn-group flex-fill">
+					<a {{{ if hasPrivateChat }}}component="account/chat"{{{ else }}}component="account/new-chat"{{{ end }}} href="#" class="btn btn-light" role="button">[[user:chat]]</a>
+					{{{ if hasPrivateChat}}}
+					<button type="button" class="btn btn-light dropdown-toggle flex-0" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+						<i class="fa fa-caret-down"></i>
+					</button>
+					<ul class="dropdown-menu dropdown-menu-end p-1 text-sm" role="menu">
+						<li><a class="dropdown-item rounded-1" href="#" component="account/new-chat" role="menuitem"s>[[user:new-chat-with, {username}]]</a></li>
+					</ul>
+					{{{ end }}}
+				</div>
+				{{{ end }}}
+				{{{ if !isSelf }}}
+				{{{ if (isAdmin || (canBan || canMute ))}}}
+				<!-- IMPORT partials/account/admin-menu.tpl -->
+				{{{ end }}}
+				{{{ end }}}
+			</div>
+		</div>
+	</div>
+
+	<div class="d-flex flex-column flex-md-row">
+		<!-- IMPORT partials/account/sidebar-left.tpl -->
+		<div class="account-content flex-grow-1 ps-md-2 ps-lg-3 ps-xl-4" style="min-width: 0;">
+

--- a/public/language/en-GB/user.json
+++ b/public/language/en-GB/user.json
@@ -2,6 +2,8 @@
 	"user-menu": "User menu",
 	"banned": "Banned",
 	"unbanned": "Unbanned",
+	"student-role": "Student",
+	"professor-role": "Professor",
 	"muted": "Muted",
 	"unmuted": "Unmuted",
 	"offline": "Offline",

--- a/public/language/en-US/user.json
+++ b/public/language/en-US/user.json
@@ -2,6 +2,8 @@
     "user-menu": "User menu",
     "banned": "Banned",
     "unbanned": "Unbanned",
+	"student-role": "Student",
+	"professor-role": "Professor",
     "muted": "Muted",
     "unmuted": "Unmuted",
     "offline": "Offline",

--- a/public/language/es/user.json
+++ b/public/language/es/user.json
@@ -2,6 +2,8 @@
     "user-menu": "User menu",
     "banned": "Baneado",
     "unbanned": "Unbanned",
+	"student-role": "Estudiante",
+	"professor-role": "Profesor",
     "muted": "Muted",
     "unmuted": "Unmuted",
     "offline": "Desconectado",


### PR DESCRIPTION
**_PR Resolve issue #12_** 
Se agregó debajo del nombre del usuario el rol que tiene este usuario dentro de la aplicaión.
Para ello se agregaron los archivos correspondientes al profile en el plugin nodebb-plugin-digitalpioneers, estos archivos fueron account/profile.tpl y partials/account/headers.tpl en este último fué donde se agregó la etiqueta, donde se utiliza la variable isAdmin de los usuarios administradores, para poder diferenciar el rol a imprimir.

Siguiendo el formato de nodebb se agregaron los valores correspondientes para student-role y professor-role en el archivo public/language/es/user.json

Aprovechando esto se agregaron valores para idioma ingles US e ingles GB.

**Procedemos a mostrar los cambios, mediante imágenes:**

**Roles para estudiantes y profesores en español:**
![est-prof-es](https://github.com/user-attachments/assets/351ca761-0edf-4ea2-8b7e-856d7a8f326f)


**Roles para estudiantes y profesores en ingles US y GB:**
![est-prof-eng](https://github.com/user-attachments/assets/9d0da7aa-d58f-472c-9bb8-64ce1a4d8fdb)
